### PR TITLE
Make errors accessable

### DIFF
--- a/cachetable.go
+++ b/cachetable.go
@@ -166,7 +166,7 @@ func (table *CacheTable) Delete(key interface{}) (*CacheItem, error) {
 	r, ok := table.items[key]
 	if !ok {
 		table.RUnlock()
-		return nil, errors.New("Key not found in cache")
+		return nil, ErrKeyNotFound
 	}
 
 	// Cache value so we don't keep blocking the mutex.
@@ -224,10 +224,10 @@ func (table *CacheTable) Value(key interface{}) (*CacheItem, error) {
 			return item, nil
 		}
 
-		return nil, errors.New("Key not found and could not be loaded into cache")
+		return nil, ErrKeyNotFoundOrLoadable
 	}
 
-	return nil, errors.New("Key not found in cache")
+	return nil, ErrKeyNotFound
 }
 
 // Delete all items from cache.

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,10 @@
+package cache2go
+
+import (
+	"errors"
+)
+
+var (
+	ErrKeyNotFound           = errors.New("Key not found in cache")
+	ErrKeyNotFoundOrLoadable = errors.New("Key not found and could not be loaded into cache")
+)


### PR DESCRIPTION
This PR moves all calls to `errors.New()` into variables so a user of this library can more easily compare them, e.g. to avoid to call `Exists()` first.

```
item, err := cache.Value("somekey")
if err != nil {
  if err == cache2go.ErrKeyNotFound {
     // do something
  } 
  // Abort horrible
}
```
